### PR TITLE
Resolve Flutter 3.29 compatibility issue with PluginRegistry

### DIFF
--- a/android/src/main/java/com/lm/http_proxy/HttpProxyPlugin.java
+++ b/android/src/main/java/com/lm/http_proxy/HttpProxyPlugin.java
@@ -6,7 +6,6 @@ import io.flutter.plugin.common.MethodCall;
 import io.flutter.plugin.common.MethodChannel;
 import io.flutter.plugin.common.MethodChannel.MethodCallHandler;
 import io.flutter.plugin.common.MethodChannel.Result;
-import io.flutter.plugin.common.PluginRegistry.Registrar;
 
 /** HttpProxyPlugin */
 public class HttpProxyPlugin implements FlutterPlugin, MethodCallHandler {
@@ -20,20 +19,6 @@ public class HttpProxyPlugin implements FlutterPlugin, MethodCallHandler {
   public void onAttachedToEngine(@NonNull FlutterPluginBinding flutterPluginBinding) {
     channel = new MethodChannel(flutterPluginBinding.getFlutterEngine().getDartExecutor(), "com.lm.http.proxy");
     channel.setMethodCallHandler(this);
-  }
-
-  // This static function is optional and equivalent to onAttachedToEngine. It supports the old
-  // pre-Flutter-1.12 Android projects. You are encouraged to continue supporting
-  // plugin registration via this function while apps migrate to use the new Android APIs
-  // post-flutter-1.12 via https://flutter.dev/go/android-project-migration.
-  //
-  // It is encouraged to share logic between onAttachedToEngine and registerWith to keep
-  // them functionally equivalent. Only one of onAttachedToEngine or registerWith will be called
-  // depending on the user's project. onAttachedToEngine or registerWith must both be defined
-  // in the same class.
-  public static void registerWith(Registrar registrar) {
-    final MethodChannel channel = new MethodChannel(registrar.messenger(), "com.lm.http.proxy");
-    channel.setMethodCallHandler(new HttpProxyPlugin());
   }
 
   @Override


### PR DESCRIPTION
In Flutter 3.16, the imperative application of Flutter’s Gradle plugins is deprecated. As a result, the PluginRegistry package in Android causes Flutter projects to crash on Android.